### PR TITLE
Fixed null reference exceptions when FormsMap or Map are null

### DIFF
--- a/TK.CustomMap/TK.CustomMap.Android/TKCustomMapRenderer.cs
+++ b/TK.CustomMap/TK.CustomMap.Android/TKCustomMapRenderer.cs
@@ -678,13 +678,14 @@ namespace TK.CustomMap.Droid
                 i.Value.Remove();
             }
             this._routes.Clear();
-            if (this.FormsMap.Routes != null)
-            {
-                foreach (var i in this.FormsMap.Routes)
-                {
-                    this.AddRoute(i);
-                }
+
+			if (this.FormsMap == null || this.FormsMap.Routes == null) return;
+
+            foreach (var i in this.FormsMap.Routes)
+			{
+                this.AddRoute(i);
             }
+
             if (firstUpdate)
             {
                 var observAble = this.FormsMap.Routes as INotifyCollectionChanged;
@@ -1005,7 +1006,7 @@ namespace TK.CustomMap.Droid
             {
                 var routeCalculationError = new TKRouteCalculationError(route, errorMessage);
 
-                if (this.FormsMap.RouteCalculationFailedCommand.CanExecute(routeCalculationError))
+				if (this.FormsMap != null && this.FormsMap.RouteCalculationFailedCommand.CanExecute(routeCalculationError))
                 {
                     this.FormsMap.RouteCalculationFailedCommand.Execute(routeCalculationError);
                 }

--- a/TK.CustomMap/TK.CustomMap.iOSUnified/TKCustomMapRenderer.cs
+++ b/TK.CustomMap/TK.CustomMap.iOSUnified/TKCustomMapRenderer.cs
@@ -576,10 +576,11 @@ namespace TK.CustomMap.iOSUnified
                 {
                     r.Value.Overlay.PropertyChanged -= OnRoutePropertyChanged;
                 }
-                this.Map.RemoveOverlays(this._routes.Select(i => i.Key).ToArray());
+				if (this.Map != null)
+                	this.Map.RemoveOverlays(this._routes.Select(i => i.Key).ToArray());
                 this._routes.Clear();
             }
-            if (this.FormsMap.Routes == null) return;
+			if (this.FormsMap == null || this.FormsMap.Routes == null) return;
 
             foreach (var route in this.FormsMap.Routes)
             {
@@ -893,11 +894,11 @@ namespace TK.CustomMap.iOSUnified
             MKDirections directions = new MKDirections(req);
             directions.CalculateDirections((r, e) => 
             {
+				if (this.FormsMap == null || this.Map == null) return;
+
                 if (e == null)
                 {
                     var nativeRoute = r.Routes.First();
-
-                    if (this.FormsMap == null || this.Map == null) return;
 
                     this.SetRouteData(route, nativeRoute);
 


### PR DESCRIPTION
I think you missed one of the fixes I sent before, but this time I've done the merge request from dev to dev, so hopefully you can accept it easier :)
