### PR TITLE
Update TKCustomMapRenderer.cs

### DIFF
--- a/TK.CustomMap/TK.CustomMap.Android/TKCustomMapRenderer.cs
+++ b/TK.CustomMap/TK.CustomMap.Android/TKCustomMapRenderer.cs
@@ -475,6 +475,8 @@ namespace TK.CustomMap.Droid
         /// <param name="pin">The Forms Pin</param>
         private async void AddPin(TKCustomMapPin pin)
         {
+	    if (this._markers.Keys.Contains(pin)) return; 
+
             pin.PropertyChanged += OnPinPropertyChanged;
 
             var markerWithIcon = new MarkerOptions();


### PR DESCRIPTION
On reset binding (change of page), pins are added again, the dictionary already contains the pins therefore the app crashes without notice...
