### PR TITLE
Missing update of circles on iOS renderer

### DIFF
--- a/TK.CustomMap/TK.CustomMap.iOSUnified/TKCustomMapRenderer.cs
+++ b/TK.CustomMap/TK.CustomMap.iOSUnified/TKCustomMapRenderer.cs
@@ -271,6 +271,10 @@ namespace TK.CustomMap.iOSUnified
             {
                 this.UpdateLines();
             }
+            else if (e.PropertyName == TKCustomMap.CirclesProperty.PropertyName)
+            {
+                this.UpdateCircles();
+            }
             else if (e.PropertyName == TKCustomMap.CalloutClickedCommandProperty.PropertyName)
             {
                 this.UpdatePins(false);


### PR DESCRIPTION
After some headaches I found that the circle property was not updated when the property was changed....
