### PR TITLE
Fix iOS hang if setting MapCenter while user panning

### DIFF
--- a/TK.CustomMap/TK.CustomMap.iOSUnified/TKCustomMapRenderer.cs
+++ b/TK.CustomMap/TK.CustomMap.iOSUnified/TKCustomMapRenderer.cs
@@ -1252,7 +1252,10 @@ namespace TK.CustomMap.iOSUnified
 
             if (!this.FormsMap.MapCenter.Equals(this.Map.CenterCoordinate.ToPosition()))
             {
-                this.Map.SetCenterCoordinate(this.FormsMap.MapCenter.ToLocationCoordinate(), this.FormsMap.IsRegionChangeAnimated);   
+                BeginInvokeOnMainThread(() =>
+                {
+                    this.Map.SetCenterCoordinate(this.FormsMap.MapCenter.ToLocationCoordinate(), this.FormsMap.IsRegionChangeAnimated);
+                });
             }
         }
         /// <summary>


### PR DESCRIPTION
This fixed a problem I discovered only on device when the code would change the bound MapCenter value _while_ the user was panning around in the map (with animation on for region changes).
