### PR TITLE
OnPinPropertyChanged: Trying to resolve an app crash

### DIFF
--- a/TK.CustomMap/TK.CustomMap.Android/TKCustomMapRenderer.cs
+++ b/TK.CustomMap/TK.CustomMap.Android/TKCustomMapRenderer.cs
@@ -351,8 +351,8 @@ namespace TK.CustomMap.Droid
             var pin = sender as TKCustomMapPin;
             if (pin == null) return;
 
-            var marker = this._markers[pin];
-            if (marker == null) return;
+            Marker marker = null;
+            if (!this._markers.ContainsKey(pin) || (marker= this._markers[pin]) == null) return;
 
             switch (e.PropertyName)
             {


### PR DESCRIPTION
  at System.ThrowHelper.ThrowKeyNotFoundException () <0x93b6f380 + 0x00010> in <filename unknown>:0 
  at System.Collections.Generic.Dictionary`2[TKey,TValue].get_Item (System.Collections.Generic.TKey key) <0x9e268420 + 0x00053> in <filename unknown>:0 
  at TK.CustomMap.Droid.TKCustomMapRenderer+<OnPinPropertyChanged>d__31.MoveNext () <0x93b6e9c0 + 0x00113> in <filename unknown>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () <0x96b3f8b8 + 0x00024> in <filename unknown>:0 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore.<ThrowAsync>m__0 (System.Object state) <0x93b6f848 + 0x0003f> in <filename unknown>:0 
  at Android.App.SyncContext+<Post>c__AnonStorey0.<>m__0 () <0x9e220040 + 0x00027> in <filename unknown>:0 
  at Java.Lang.Thread+RunnableImplementor.Run () <0x9e21fe78 + 0x0003f> in <filename unknown>:0 
  at Java.Lang.IRunnableInvoker.n_Run (IntPtr jnienv, IntPtr native__this) <0x9e21f8d8 + 0x0003f> in <filename unknown>:0 
  at (wrapper dynamic-method) System.Object:b104a923-fb52-4f4f-bc23-11a5d78f4107 (intptr,intptr)
    at mono.java.lang.RunnableImplementor.n_run(Native Method)
    at mono.java.lang.RunnableImplementor.run(RunnableImplementor.java:30)
    at android.os.Handler.handleCallback(Handler.java:739)
    at android.os.Handler.dispatchMessage(Handler.java:95)
    at android.os.Looper.loop(Looper.java:168)
    at android.app.ActivityThread.main(ActivityThread.java:5885)
    ... 3 more
