### PR TITLE
Cleanup after disconnect

### DIFF
--- a/TK.CustomMap/TK.CustomMap.Android/DependencyServices/NativePlacesApi.cs
+++ b/TK.CustomMap/TK.CustomMap.Android/DependencyServices/NativePlacesApi.cs
@@ -88,9 +88,13 @@ namespace TK.CustomMap.Droid
                 this._apiClient.Disconnect();
 
             this._apiClient.Dispose();
+            this._apiClient = null;
 
             if (this._buffer != null)
+            {
                 this._buffer.Dispose();
+                this._buffer = null;
+            }
         }
         /// <inheritdoc/>
         public async Task<TKPlaceDetails> GetDetails(string id)


### PR DESCRIPTION
Disconnect is leaving around a disposed _apiClient reference, which the code then attempts to reuse. Setting the reference to null should fix that.
