### PR TITLE
Added ID field to CustomMapPin

### DIFF
--- a/CalloutSample/CalloutSample/App.cs
+++ b/CalloutSample/CalloutSample/App.cs
@@ -26,6 +26,7 @@ namespace CalloutSample
                             {
                                 new TKCustomMapPin
                                 {
+                                    ID = "123", //optional ID for the client app to refer to
                                     Title = "Custom Callout Sample",
                                     Position = new Position(40.7142700, -74.0059700),
                                     ShowCallout = true

--- a/TK.CustomMap/TK.CustomMap/TKCustomMapPin.cs
+++ b/TK.CustomMap/TK.CustomMap/TKCustomMapPin.cs
@@ -9,6 +9,7 @@ namespace TK.CustomMap
     public class TKCustomMapPin : TKBase
     {
         private bool _isVisible;
+        private string _id;
         private string _title;
         private string _subtitle;
         private bool _showCallout;
@@ -18,6 +19,7 @@ namespace TK.CustomMap
         private Color _defaultPinColor;
         private Point _anchor;
 
+        public const string IDPropertyName = "ID";
         public const string TitlePropertyName = "Title";
         public const string SubititlePropertyName = "Subtitle";
         public const string PositionPropertyName = "Position";
@@ -35,6 +37,14 @@ namespace TK.CustomMap
         {
             get { return this._isVisible; }
             set { this.SetField(ref this._isVisible, value); }
+        }
+        /// <summary>
+        /// Gets/Sets ID of the pin, used for client app reference (optional)
+        /// </summary>
+        public string ID
+        {
+            get { return this._id; }
+            set { this.SetField(ref this._id, value); }
         }
         /// <summary>
         /// Gets/Sets title of the pin displayed in the callout


### PR DESCRIPTION
Added a client trackable "ID" field to pin.  This way, pins can be given an ID when added to the map, and when clicked, the app knows which pin to refer to or handle.  This is similar (and critical) to other mapping APIs (but apparently Xamarin left it out.)
